### PR TITLE
Add specialized order types: ExpressOrder and GiftOrder

### DIFF
--- a/src/main/java/org/tc/ecommerce/OrderRepository.java
+++ b/src/main/java/org/tc/ecommerce/OrderRepository.java
@@ -1,5 +1,7 @@
 package org.tc.ecommerce;
 
+import org.tc.ecommerce.orders.Order;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/org/tc/ecommerce/OrderService.java
+++ b/src/main/java/org/tc/ecommerce/OrderService.java
@@ -1,6 +1,8 @@
 package org.tc.ecommerce;
 
 
+import org.tc.ecommerce.orders.Order;
+
 import java.util.List;
 
 public class OrderService {

--- a/src/main/java/org/tc/ecommerce/orders/ExpressOrder.java
+++ b/src/main/java/org/tc/ecommerce/orders/ExpressOrder.java
@@ -1,0 +1,14 @@
+package org.tc.ecommerce.orders;
+
+import org.tc.ecommerce.Product;
+
+import java.util.List;
+
+public class ExpressOrder extends Order{
+    private double priorityFee;
+
+    public ExpressOrder(List<Product> products, double priorityFee) {
+        super(products);
+        this.priorityFee = priorityFee;
+    }
+}

--- a/src/main/java/org/tc/ecommerce/orders/GiftOrder.java
+++ b/src/main/java/org/tc/ecommerce/orders/GiftOrder.java
@@ -1,0 +1,15 @@
+package org.tc.ecommerce.orders;
+
+import org.tc.ecommerce.Product;
+
+import java.util.List;
+
+public class GiftOrder extends Order{
+
+    private String giftNote;
+
+    public GiftOrder(List<Product> products, String giftNote) {
+        super(products);
+        this.giftNote = giftNote;
+    }
+}

--- a/src/main/java/org/tc/ecommerce/orders/Order.java
+++ b/src/main/java/org/tc/ecommerce/orders/Order.java
@@ -1,6 +1,7 @@
-package org.tc.ecommerce;
+package org.tc.ecommerce.orders;
 
 import lombok.*;
+import org.tc.ecommerce.Product;
 
 import java.util.Date;
 import java.util.List;
@@ -11,10 +12,10 @@ import java.util.UUID;
 @ToString
 @EqualsAndHashCode
 public class Order {
-    private String orderId;
-    private Date orderDate;
-    private boolean isCanclled;
-    private List<Product> products;
+    protected String orderId;
+    protected Date orderDate;
+    protected boolean isCanclled;
+    protected List<Product> products;
 
     public  Order(final List<Product> products) {
         this.orderId = UUID.randomUUID().toString(); // Auto-generate UUID as String

--- a/src/main/java/org/tc/ecommerce/users/AdminUser.java
+++ b/src/main/java/org/tc/ecommerce/users/AdminUser.java
@@ -1,6 +1,6 @@
 package org.tc.ecommerce.users;
 
-import org.tc.ecommerce.Order;
+import org.tc.ecommerce.orders.Order;
 import org.tc.ecommerce.OrderService;
 
 public class AdminUser extends User{

--- a/src/main/java/org/tc/ecommerce/users/CustomerUser.java
+++ b/src/main/java/org/tc/ecommerce/users/CustomerUser.java
@@ -1,7 +1,7 @@
 package org.tc.ecommerce.users;
 
 import org.tc.ecommerce.Cart;
-import org.tc.ecommerce.Order;
+import org.tc.ecommerce.orders.Order;
 import org.tc.ecommerce.OrderService;
 import org.tc.ecommerce.Product;
 


### PR DESCRIPTION
Add specialized order types: ExpressOrder and GiftOrder

- Introduced ExpressOrder class extending Order with a priorityFee for expedited processing.
- Added GiftOrder class extending Order with a giftNote for personalized messages.
- Simplified Order class to support inheritance for different order types.